### PR TITLE
Add function to dump gtfs to files

### DIFF
--- a/gtfs.go
+++ b/gtfs.go
@@ -115,7 +115,7 @@ func loadGTFS(g *GTFS, filter map[string]bool) error {
 func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
 	_, err := os.Stat(dirPath)
 	if os.IsNotExist(err) {
-		return fmt.Errorf("Error dumping GTFS: target directory doesn't exist")
+		os.MkdirAll(dirPath, os.ModeDir)
 	}
 
 	files := map[string]interface{}{

--- a/gtfs.go
+++ b/gtfs.go
@@ -113,34 +113,34 @@ func loadGTFS(g *GTFS, filter map[string]bool) error {
 // @param filter: same as for load function
 // @return error
 func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
-    _, err := os.Stat(dirPath)
-    if os.IsNotExist(err) {
-        return fmt.Errorf("Error dumping GTFS: target directory doesn't exist")
-    }
+	_, err := os.Stat(dirPath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("Error dumping GTFS: target directory doesn't exist")
+	}
 
-    files := map[string]interface{}{
-        "agency.txt":         []Agency{g.Agency},
-		"calendar.txt":       g.Calendars,
-		"calendar_dates.txt": g.CalendarDates,
-		"routes.txt":         g.Routes,
-		"stops.txt":          g.Stops,
-		"stop_times.txt":     g.StopsTimes,
-		"transfers.txt":      g.Transfers,
-		"trips.txt":          g.Trips,
-    }
-    for file, src := range files {
-        if filter != nil && !filter[file[:len(file)-4]] {
-            continue
-        }
-        if src == nil {
-            continue
-        }
-        filePath := path.Join(dirPath, file)
+	files := map[string]interface{}{
+		"agency.txt":			[]Agency{g.Agency},
+		"calendar.txt":			g.Calendars,
+		"calendar_dates.txt": 	g.CalendarDates,
+		"routes.txt":			g.Routes,
+		"stops.txt":			g.Stops,
+		"stop_times.txt":		g.StopsTimes,
+		"transfers.txt":		g.Transfers,
+		"trips.txt":			g.Trips,
+	}
+	for file, src := range files {
+		if filter != nil && !filter[file[:len(file)-4]] {
+			continue
+		}
+		if src == nil {
+			continue
+		}
+		filePath := path.Join(dirPath, file)
 
-        err := csvtag.DumpToFile(src, filePath)
-        if err != nil {
-            return fmt.Errorf("Error dumping file %v: %v", file, err)
-        }
-    }
-    return err
+		err := csvtag.DumpToFile(src, filePath)
+		if err != nil {
+			return fmt.Errorf("Error dumping file %v: %v", file, err)
+		}
+	}
+	return err
 }

--- a/gtfs.go
+++ b/gtfs.go
@@ -115,7 +115,12 @@ func loadGTFS(g *GTFS, filter map[string]bool) error {
 func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
 	_, err := os.Stat(dirPath)
 	if os.IsNotExist(err) {
-		os.MkdirAll(dirPath, os.ModeDir)
+		err = os.MkdirAll(dirPath, os.ModeDir)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
 	}
 
 	files := map[string]interface{}{

--- a/gtfs.go
+++ b/gtfs.go
@@ -118,11 +118,8 @@ func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
         return fmt.Errorf("Error dumping GTFS: target directory doesn't exist")
     }
 
-    agencySlice := make([]Agency, 1)
-    agencySlice[0] = g.Agency
-
     files := map[string]interface{}{
-        "agency.txt":         agencySlice,
+        "agency.txt":         []Agency{g.Agency},
 		"calendar.txt":       g.Calendars,
 		"calendar_dates.txt": g.CalendarDates,
 		"routes.txt":         g.Routes,

--- a/gtfs.go
+++ b/gtfs.go
@@ -147,5 +147,5 @@ func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
 			return fmt.Errorf("Error dumping file %v: %v", file, err)
 		}
 	}
-	return err
+	return nil
 }

--- a/gtfs.go
+++ b/gtfs.go
@@ -115,7 +115,7 @@ func loadGTFS(g *GTFS, filter map[string]bool) error {
 func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
 	_, err := os.Stat(dirPath)
 	if os.IsNotExist(err) {
-		err = os.MkdirAll(dirPath, os.ModeDir)
+		err = os.MkdirAll(dirPath, os.ModeDir | 0755)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This dumps a given gtfs-struct to a given path and accepts the same filters as `Load()` does.

Unfortunately, due to the current implementation of go-csv-tag, `Dump()` can only accept slices, not pointers to slices; hence the pass by value.

This is good enough for what I am using it for right now, but especially with bigger structures, passing the slices by reference would be nicer.

If you'd like, I can take a look at changing the implementation of `Dump` to also accept pointers to slices; this would require the use of reflection, which I don't have much experience with so far.

Thanks for your good work,
Adrian