### PR TITLE
Support for multiple agencies

### DIFF
--- a/gtfs.go
+++ b/gtfs.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/artonge/go-csv-tag/v2"
+	csvtag "github.com/artonge/go-csv-tag/v2"
 )
 
 // Load - load GTFS files
@@ -67,11 +67,9 @@ func LoadSplitted(dirPath string, filter map[string]bool) ([]*GTFS, error) {
 // @param g: the GTFS struct that will receive the data
 // @return an error
 func loadGTFS(g *GTFS, filter map[string]bool) error {
-	// Create a slice of agency to load agency.txt
-	var agencySlice []Agency
 	// List all files that will be loaded and there dest
 	filesToLoad := map[string]interface{}{
-		"agency.txt":         &agencySlice,
+		"agency.txt":         &g.Agencies,
 		"calendar.txt":       &g.Calendars,
 		"calendar_dates.txt": &g.CalendarDates,
 		"routes.txt":         &g.Routes,
@@ -97,10 +95,7 @@ func loadGTFS(g *GTFS, filter map[string]bool) error {
 			return fmt.Errorf("Error loading file (%v)\n	==> %v", file, err)
 		}
 	}
-	// Put the loaded agency in g.Agency
-	if len(agencySlice) > 0 {
-		g.Agency = agencySlice[0]
-	}
+
 	return nil
 }
 
@@ -121,7 +116,7 @@ func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
 	}
 
 	files := map[string]interface{}{
-		"agency.txt":         []Agency{g.Agency},
+		"agency.txt":         g.Agencies,
 		"calendar.txt":       g.Calendars,
 		"calendar_dates.txt": g.CalendarDates,
 		"routes.txt":         g.Routes,

--- a/gtfs.go
+++ b/gtfs.go
@@ -96,6 +96,10 @@ func loadGTFS(g *GTFS, filter map[string]bool) error {
 		}
 	}
 
+	if len(g.Agencies) > 0 {
+		g.Agency = g.Agencies[0]
+	}
+
 	return nil
 }
 
@@ -113,6 +117,17 @@ func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
 		}
 	} else if err != nil {
 		return err
+	}
+
+	agencyIsIn := false
+	for _, agency := range g.Agencies {
+		if agency == g.Agency {
+			agencyIsIn = true
+		}
+	}
+
+	if !agencyIsIn {
+		g.Agencies = append(g.Agencies, g.Agency)
 	}
 
 	files := map[string]interface{}{

--- a/gtfs_test.go
+++ b/gtfs_test.go
@@ -12,7 +12,8 @@ func TestLoad(t *testing.T) {
 		fmt.Println(err)
 		t.Fail()
 	}
-	if len(gtfs.Calendars) == 0 ||
+	if len(gtfs.Agencies) == 0 ||
+		len(gtfs.Calendars) == 0 ||
 		len(gtfs.CalendarDates) == 0 ||
 		len(gtfs.Routes) == 0 ||
 		len(gtfs.Stops) == 0 ||
@@ -43,7 +44,8 @@ func TestLoadPartial(t *testing.T) {
 		fmt.Println(err)
 		t.Fail()
 	}
-	if len(gtfs.Calendars) != 0 ||
+	if len(gtfs.Agencies) != 0 ||
+		len(gtfs.Calendars) != 0 ||
 		len(gtfs.CalendarDates) != 0 ||
 		len(gtfs.Routes) == 0 ||
 		len(gtfs.Stops) != 0 ||

--- a/gtfs_test.go
+++ b/gtfs_test.go
@@ -22,6 +22,10 @@ func TestLoad(t *testing.T) {
 		len(gtfs.Trips) == 0 {
 		t.Fail()
 	}
+
+	if gtfs.Agencies[0] != gtfs.Agency {
+		t.Fail()
+	}
 }
 
 func TestLoadBad(t *testing.T) {

--- a/gtfs_test/ratp/agency.txt
+++ b/gtfs_test/ratp/agency.txt
@@ -1,2 +1,3 @@
 agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone
 100,RATP (100),http://www.ratp.fr/,CET,,
+101,RATP (101),http://www.ratp.fr/,CET,,

--- a/gtfs_test/ratp/routes.txt
+++ b/gtfs_test/ratp/routes.txt
@@ -1,3 +1,5 @@
 route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color
 1684968,100,"20","(GARE SAINT-LAZARE <-> GARE DE LYON.) - Aller",,3,,FFFFFF,000000
 1684969,100,"20","(GARE SAINT-LAZARE <-> GARE DE LYON.) - Retour",,3,,FFFFFF,000000
+1684970,101,"21","(GARE SAINT-LAZARE <-> GARE DE LYON.) - Aller",,3,,FFFFFF,000000
+1684971,101,"21","(GARE SAINT-LAZARE <-> GARE DE LYON.) - Retour",,3,,FFFFFF,000000

--- a/models.go
+++ b/models.go
@@ -3,7 +3,7 @@ package gtfs
 // GTFS -
 type GTFS struct {
 	Path          string // The path to the containing directory
-	Agency        Agency
+	Agencies      []Agency
 	Routes        []Route
 	Stops         []Stop
 	StopsTimes    []StopTime

--- a/models.go
+++ b/models.go
@@ -3,6 +3,7 @@ package gtfs
 // GTFS -
 type GTFS struct {
 	Path          string // The path to the containing directory
+	Agency        Agency
 	Agencies      []Agency
 	Routes        []Route
 	Stops         []Stop


### PR DESCRIPTION
Beware this is a breaking change as the GTFS model has been changed from using a single `Agency` to to `Agencies []Agency`. 

I've added another agency to the test feed, with a couple of empty routes.

Fix #15 