### PR TITLE
Add more supported file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,17 @@ It is kept compatible with changes in the Go ecosystem but no new features will 
 ```bash
 path/to/gtfs_files
 ├── agency.txt
+├── attributions.txt
 ├── calendar_dates.txt
 ├── calendar.txt
+├── fare_attributes.txt
+├── fare_rules.txt
+├── feed_info.txt
+├── frequencies.txt
+├── levels.txt
+├── pathways.txt
 ├── routes.txt
+├── shapes.txt
 ├── stops.txt
 ├── stop_times.txt
 ├── transfers.txt
@@ -35,18 +43,35 @@ g, err := gtfs.Load("path/to/gtfs_files", nil)
 ```bash
 path/to/gtfs_directories
 ├── gtfs1
-│   ├── agency.txt
-│   ├── calendar_dates.txt
-│   ├── routes.txt
-│   ├── stops.txt
-│   ├── stop_times.txt
-│   ├── transfers.txt
-│   └── trips.txt
+│   ├── agency.txt
+│   ├── attributions.txt
+│   ├── calendar_dates.txt
+│   ├── calendar.txt
+│   ├── fare_attributes.txt
+│   ├── fare_rules.txt
+│   ├── feed_info.txt
+│   ├── frequencies.txt
+│   ├── levels.txt
+│   ├── pathways.txt
+│   ├── routes.txt
+│   ├── shapes.txt
+│   ├── stops.txt
+│   ├── stop_times.txt
+│   ├── transfers.txt
+│   └── trips.txt
 └── gtfs2
     ├── agency.txt
+    ├── attributions.txt
     ├── calendar_dates.txt
     ├── calendar.txt
+    ├── fare_attributes.txt
+    ├── fare_rules.txt
+    ├── feed_info.txt
+    ├── frequencies.txt
+    ├── levels.txt
+    ├── pathways.txt
     ├── routes.txt
+    ├── shapes.txt
     ├── stops.txt
     ├── stop_times.txt
     ├── transfers.txt
@@ -61,14 +86,24 @@ You can then access the data through the GTFS structure.
 That structure contains arrays of approriate structures for each files.
 ```go
 type GTFS struct {
-	Path       string // The path to the containing directory
-	Agency     Agency
-	Routes     []Route
-	Stops      []Stop
-	StopsTimes []Stop
-	Trips      []Trip
-	Calendars  []Calendar
-	Transfers  []Transfer
+	Path           string // The path to the containing directory
+	Agency         Agency
+	Agencies       []Agency
+	Attributions   []Attribution
+	Calendars      []Calendar
+	CalendarDates  []CalendarDate
+	FareAttributes []FareAttribute
+	FareRules      []FareRule
+	FeedInfos      []FeedInfo
+	Frequencies    []Frequency
+	Levels         []Level
+	Routes         []Route
+	Pathways       []Pathway
+	Shapes         []Shape
+	Stops          []Stop
+	StopsTimes     []StopTime
+	Trips          []Trip
+	Transfers      []Transfer
 }
 
 type Route struct {

--- a/const.go
+++ b/const.go
@@ -13,4 +13,25 @@ const (
 
 	ExceptionTypeAdded   = 1
 	ExceptionTypeRemoved = 2
+
+	PaymentMethodOnBoard        = 0
+	PaymentMethodBeforeBoarding = 1
+
+	TransfersNotPermitted = 0
+	TransfersAtMostOnce   = 1
+	TransfersAtMostTwice  = 2
+
+	AttributionHasNoRole = 0
+	AttributionHasRole   = 1
+
+	PathwayWalkway        = 1
+	PathwayStairs         = 2
+	PathwayMovingSidewalk = 3
+	PathwayEscalator      = 4
+	PathwayElevator       = 5
+	PathwayFareGate       = 6
+	PathwayExitGate       = 7
+
+	PathwayUnidirectional = 0
+	PathwayBidirectional  = 1
 )

--- a/gtfs.go
+++ b/gtfs.go
@@ -69,14 +69,22 @@ func LoadSplitted(dirPath string, filter map[string]bool) ([]*GTFS, error) {
 func loadGTFS(g *GTFS, filter map[string]bool) error {
 	// List all files that will be loaded and there dest
 	filesToLoad := map[string]interface{}{
-		"agency.txt":         &g.Agencies,
-		"calendar.txt":       &g.Calendars,
-		"calendar_dates.txt": &g.CalendarDates,
-		"routes.txt":         &g.Routes,
-		"stops.txt":          &g.Stops,
-		"stop_times.txt":     &g.StopsTimes,
-		"transfers.txt":      &g.Transfers,
-		"trips.txt":          &g.Trips,
+		"agency.txt":          &g.Agencies,
+		"attributions.txt":    &g.Attributions,
+		"calendar.txt":        &g.Calendars,
+		"calendar_dates.txt":  &g.CalendarDates,
+		"fare_attributes.txt": &g.FareAttributes,
+		"fare_rules.txt":      &g.FareRules,
+		"feed_info.txt":       &g.FeedInfos,
+		"frequencies.txt":     &g.Frequencies,
+		"levels.txt":          &g.Levels,
+		"routes.txt":          &g.Routes,
+		"pathways.txt":        &g.Pathways,
+		"shapes.txt":          &g.Shapes,
+		"stops.txt":           &g.Stops,
+		"stop_times.txt":      &g.StopsTimes,
+		"transfers.txt":       &g.Transfers,
+		"trips.txt":           &g.Trips,
 	}
 	// Load the files
 	for file, dest := range filesToLoad {
@@ -131,14 +139,22 @@ func Dump(g *GTFS, dirPath string, filter map[string]bool) error {
 	}
 
 	files := map[string]interface{}{
-		"agency.txt":         g.Agencies,
-		"calendar.txt":       g.Calendars,
-		"calendar_dates.txt": g.CalendarDates,
-		"routes.txt":         g.Routes,
-		"stops.txt":          g.Stops,
-		"stop_times.txt":     g.StopsTimes,
-		"transfers.txt":      g.Transfers,
-		"trips.txt":          g.Trips,
+		"agency.txt":          g.Agencies,
+		"attributions.txt":    g.Attributions,
+		"calendar.txt":        g.Calendars,
+		"calendar_dates.txt":  g.CalendarDates,
+		"fare_attributes.txt": g.FareAttributes,
+		"fare_rules.txt":      g.FareRules,
+		"feed_info.txt":       g.FeedInfos,
+		"frequencies.txt":     g.Frequencies,
+		"levels.txt":          g.Levels,
+		"routes.txt":          g.Routes,
+		"pathways.txt":        g.Pathways,
+		"shapes.txt":          g.Shapes,
+		"stops.txt":           g.Stops,
+		"stop_times.txt":      g.StopsTimes,
+		"transfers.txt":       g.Transfers,
+		"trips.txt":           g.Trips,
 	}
 	for file, src := range files {
 		if filter != nil && !filter[file[:len(file)-4]] {

--- a/models.go
+++ b/models.go
@@ -2,16 +2,24 @@ package gtfs
 
 // GTFS -
 type GTFS struct {
-	Path          string // The path to the containing directory
-	Agency        Agency
-	Agencies      []Agency
-	Routes        []Route
-	Stops         []Stop
-	StopsTimes    []StopTime
-	Trips         []Trip
-	Calendars     []Calendar
-	CalendarDates []CalendarDate
-	Transfers     []Transfer
+	Path           string // The path to the containing directory
+	Agency         Agency
+	Agencies       []Agency
+	Attributions   []Attribution
+	Calendars      []Calendar
+	CalendarDates  []CalendarDate
+	FareAttributes []FareAttribute
+	FareRules      []FareRule
+	FeedInfos      []FeedInfo
+	Frequencies    []Frequency
+	Levels         []Level
+	Routes         []Route
+	Pathways       []Pathway
+	Shapes         []Shape
+	Stops          []Stop
+	StopsTimes     []StopTime
+	Trips          []Trip
+	Transfers      []Transfer
 }
 
 // Route -
@@ -98,4 +106,93 @@ type Agency struct {
 	Timezone string `csv:"agency_timezone"`
 	Langue   string `csv:"agency_lang"`
 	Phone    string `csv:"agency_phone"`
+}
+
+// Attribution -
+type Attribution struct {
+	ID               string `csv:"attribution_id"`
+	AgencyID         string `csv:"agency_id"`
+	RouteID          string `csv:"route_id"`
+	TripID           string `csv:"trip_id"`
+	OrganizationName string `csv:"organization_name"`
+	IsProducer       int    `csv:"is_producer"`
+	IsOperator       int    `csv:"is_operator"`
+	IsAuthority      int    `csv:"is_authority"`
+	Url              string `csv:"attribution_url"`
+	Email            string `csv:"attribution_email"`
+	Phone            string `csv:"attribution_phone"`
+}
+
+// Frequency -
+type Frequency struct {
+	TripId         string `csv:"trip_id"`
+	StartTime      string `csv:"start_time"`
+	EndTime        string `csv:"end_time"`
+	HeadwaySeconds uint32 `csv:"headway_secs"`
+	ExactTimes     string `csv:"exact_times"`
+}
+
+// FeedInfo -
+type FeedInfo struct {
+	PublisherName   string `csv:"feed_publisher_name"`
+	PublisherUrl    string `csv:"feed_publisher_url"`
+	Language        string `csv:"feed_lang"`
+	DefaultLanguage string `csv:"default_lang"`
+	StartDate       string `csv:"feed_start_date"`
+	EndDate         string `csv:"feed_end_date"`
+	Version         string `csv:"feed_version"`
+	ContactEmail    string `csv:"feed_contact_email"`
+	ContactUrl      string `csv:"feed_contact_url"`
+}
+
+// Level -
+type Level struct {
+	ID    string  `csv:"level_id"`
+	Index float64 `csv:"level_index"`
+	Name  string  `csv:"level_name"`
+}
+
+// FareAttribute -
+type FareAttribute struct {
+	ID               string  `csv:"fare_id"`
+	Price            float64 `csv:"price"`
+	CurrencyType     string  `csv:"currency_type"`
+	PaymentMethod    int     `csv:"payment_method"`
+	Transfers        int     `csv:"transfers"`
+	AgencyID         string  `csv:"agency_id"`
+	TransferDuration string  `csv:"transfer_duration"`
+}
+
+// FareRule -
+type FareRule struct {
+	ID            string `csv:"fare_id"`
+	RouteID       string `csv:"route_id"`
+	OriginID      string `csv:"origin_id"`
+	DestinationID string `csv:"destination_id"`
+	ContainsID    int    `csv:"contains_id"`
+}
+
+// Pathway -
+type Pathway struct {
+	ID                   string  `csv:"pathway_id"`
+	FromStopID           string  `csv:"from_stop_id"`
+	ToStopID             string  `csv:"to_stop_id"`
+	PathwayMode          int     `csv:"pathway_mode"`
+	IsBidirectional      int     `csv:"is_bidirectional"`
+	Length               float64 `csv:"length"`
+	TraversalTime        uint32  `csv:"traversal_time"`
+	StairCount           int     `csv:"stair_count"`
+	MaxSlope             float64 `csv:"max_slope"`
+	MinWidth             float64 `csv:"min_width"`
+	SignpostedAs         string  `csv:"signposted_as"`
+	ReversedSignpostedAs string  `csv:"reversed_signposted_as"`
+}
+
+// Shape -
+type Shape struct {
+	ID               string  `csv:"shape_id"`
+	PointLatitude    float64 `csv:"shape_pt_lat"`
+	PointLongitude   float64 `csv:"shape_pt_lon"`
+	PointSequence    uint32  `csv:"shape_pt_sequence"`
+	DistanceTraveled float64 `csv:"shape_dist_traveled"`
 }


### PR DESCRIPTION
Adds support for:

- [attributions.txt](https://developers.google.com/transit/gtfs/reference#attributionstxt)
- [fare_attributes.txt](https://developers.google.com/transit/gtfs/reference#fare_attributestxt)
- [fare_rules.txt](https://developers.google.com/transit/gtfs/reference#fare_rulestxt)
- [feed_info.txt](https://developers.google.com/transit/gtfs/reference#feed_infotxt)
- [frequencies.txt](https://developers.google.com/transit/gtfs/reference#frequenciestxt)
- [levels.txt](https://developers.google.com/transit/gtfs/reference#levelstxt)
- [pathways.txt](https://developers.google.com/transit/gtfs/reference#pathwaystxt)
- [shapes.txt](https://developers.google.com/transit/gtfs/reference#shapestxt)